### PR TITLE
add support for TRUSTED_HEADER

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,7 @@ jobs:
       - name: run pre-commit
         uses: pre-commit/action@v3.0.1
         env:
-          SKIP: no-commit-to-branch
+          SKIP: no-commit-to-branch,golangci-lint
 
   golangci-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,4 +43,4 @@ jobs:
 
       # https://github.com/golangci/golangci-lint-action
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ lint: main.go
 	go vet
 	staticcheck
 
-# test:
-# 	@echo '==> Testing'
-# 	go test -v
+test:
+	@echo '==> Testing'
+	go test -v clientip/*.go
 
 clean:
 	@echo '==> Cleaning'

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ In addition to the CLI flags described below, the following envvars can configur
 | `LISTEN_ADDR`     | `0.0.0.0:8000` | the host and port number to receive request on                                             |
 | `TRUST_XFF`       | `false`        | trust X-Forwarded-For headers in the request (only enable if running behind a proxy)       |
 | `TRUSTED_PROXIES` | ``             | comma-separated list of IP blocks (in CIDR-notation) that upstream proxy request come from |
+| `TRUSTED_HEADER`  | ``             | the name of a trusted header which provides the client IP address directly                 |
 
 ## Usage
 
@@ -30,6 +31,7 @@ VERSION:
 GLOBAL OPTIONS:
    --loglevel string        how verbosely to log, one of: DEBUG, INFO, WARN, ERROR (default: "INFO") [$LOG_LEVEL]
    --listenaddr string      IP address and port to listen on (default: "0.0.0.0:8000") [$LISTEN_ADDR]
+   --trustedheader string   the name of a trusted header which provides the client IP address directly [$TRUSTED_HEADER]
    --trustxff               trust X-Forwarded-For headers in the request (only enable if running behind a proxy) (default: false) [$TRUST_XFF]
    --trustedproxies string  comma-separated list of IP blocks (in CIDR-notation) that upstream proxy request come from [$TRUSTED_PROXIES]
    --help, -h               show help

--- a/clientip/clientip.go
+++ b/clientip/clientip.go
@@ -63,10 +63,8 @@ func GetClientIP(req *http.Request, trustXFF bool, trustedProxies *TrustedProxie
 		if ip := req.Header.Get(trustedHeader); ip != "" {
 			return ip
 		}
-		goto FALLBACK
-	}
-
-	if trustXFF && trustedProxies != nil {
+		// fallback below
+	} else if trustXFF && trustedProxies != nil {
 		xffs := req.Header.Values("X-Forwarded-For")
 		var ips []string
 		if len(xffs) > 0 {
@@ -89,7 +87,6 @@ func GetClientIP(req *http.Request, trustXFF bool, trustedProxies *TrustedProxie
 		// All XFF IPs are trusted, fall back to RemoteAddr
 	}
 
-FALLBACK:
 	// Fallback: extract host (IP) from RemoteAddr
 	host, _, err := net.SplitHostPort(req.RemoteAddr)
 	if err == nil && host != "" {

--- a/clientip/clientip_test.go
+++ b/clientip/clientip_test.go
@@ -5,15 +5,13 @@ import (
 	"testing"
 )
 
-func makeRequest(xffHeaders []string, remoteAddr string, extraHeaders *map[string]string) *http.Request {
+func makeRequest(xffHeaders []string, remoteAddr string, extraHeaders map[string]string) *http.Request {
 	req, _ := http.NewRequest("GET", "/", nil)
 	for _, h := range xffHeaders {
 		req.Header.Add("X-Forwarded-For", h)
 	}
-	if extraHeaders != nil {
-		for k, v := range *(extraHeaders) {
-			req.Header.Add(k, v)
-		}
+	for k, v := range extraHeaders {
+		req.Header.Add(k, v)
 	}
 	req.RemoteAddr = remoteAddr
 	return req
@@ -29,7 +27,7 @@ func TestGetClientIP(t *testing.T) {
 		trustXFF       bool
 		trustedProxies *TrustedProxies
 		trustedHeader  string
-		extraHeaders   *map[string]string
+		extraHeaders   map[string]string
 		want           string
 	}{
 		{
@@ -109,7 +107,7 @@ func TestGetClientIP(t *testing.T) {
 			trustXFF:       true,
 			trustedProxies: nil,
 			trustedHeader:  "X-Client-IP-For-Real",
-			extraHeaders: &map[string]string{
+			extraHeaders: map[string]string{
 				"X-Client-IP-For-Real": "4.4.4.4",
 				"X-Client-IP":          "7.6.5.4",
 			},
@@ -122,7 +120,7 @@ func TestGetClientIP(t *testing.T) {
 			trustXFF:       true,
 			trustedProxies: nil,
 			trustedHeader:  "X-Client-IP-Wrong",
-			extraHeaders: &map[string]string{
+			extraHeaders: map[string]string{
 				"X-Client-IP-For-Real": "4.4.4.4",
 				"X-Client-IP":          "7.6.5.4",
 			},

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/backplane/myip
 
-go 1.22
+go 1.24
 
 require github.com/urfave/cli/v3 v3.3.3

--- a/handlers.go
+++ b/handlers.go
@@ -10,8 +10,6 @@ import (
 
 // HandleMyIP is an http endpoint that returns the IP address of the requester
 func (cfg *Config) HandleMyIP(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
 	// Accepting HTTP GETs only
 	if r.Method != http.MethodGet {
 		logger.Warn("invalid request method", "method", r.Method)
@@ -25,5 +23,8 @@ func (cfg *Config) HandleMyIP(w http.ResponseWriter, r *http.Request) {
 	ip := clientip.GetClientIP(r, cfg.trustXFF, cfg.trustedProxies, cfg.trustedHeader)
 
 	w.Header().Add(`Content-Type`, `application/json`)
-	fmt.Fprintf(w, "{\"ip\": \"%s\"}\n", ip)
+	_, err := fmt.Fprintf(w, "{\"ip\": \"%s\"}\n", ip)
+	if err != nil {
+		logger.Error("error writing response", "error", err)
+	}
 }

--- a/handlers.go
+++ b/handlers.go
@@ -22,7 +22,7 @@ func (cfg *Config) HandleMyIP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ip := clientip.GetClientIP(r, cfg.trustXFF, cfg.trustedProxies)
+	ip := clientip.GetClientIP(r, cfg.trustXFF, cfg.trustedProxies, cfg.trustedHeader)
 
 	w.Header().Add(`Content-Type`, `application/json`)
 	fmt.Fprintf(w, "{\"ip\": \"%s\"}\n", ip)

--- a/main.go
+++ b/main.go
@@ -46,9 +46,11 @@ func setLogLevel(level string) {
 
 func init() {
 	cli.VersionPrinter = func(cmd *cli.Command) {
-		fmt.Fprintf(cmd.Root().Writer, "myip version %s; commit %s; built on %s; by %s\n", version, commit, date, builtBy)
+		_, err := fmt.Fprintf(cmd.Root().Writer, "myip version %s; commit %s; built on %s; by %s\n", version, commit, date, builtBy)
+		if err != nil {
+			panic("failed to write out version information")
+		}
 	}
-
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -130,7 +130,7 @@ func main() {
 	}
 
 	if err := cmd.Run(context.Background(), os.Args); err != nil {
-		logger.Error("error while listening for API connections",
+		logger.Error("error while listening for connections",
 			"error", err)
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 
 type Config struct {
 	trustedProxies *clientip.TrustedProxies
+	trustedHeader  string
 	trustXFF       bool
 	listenAddr     string
 }
@@ -71,6 +72,12 @@ func main() {
 				Usage:   "IP address and port to listen on",
 				Sources: cli.EnvVars("LISTEN_ADDR"),
 			},
+			&cli.StringFlag{
+				Name:    "trustedheader",
+				Value:   "",
+				Usage:   "the name of a trusted header which provides the client IP address directly",
+				Sources: cli.EnvVars("TRUSTED_HEADER"),
+			},
 			&cli.BoolFlag{
 				Name:    "trustxff",
 				Value:   false,
@@ -106,6 +113,7 @@ func main() {
 				"listenaddr", cfg.listenAddr,
 				"trustxff", cfg.trustXFF,
 				"trustedproxies", cfg.trustedProxies,
+				"trustedheader", cfg.trustedHeader,
 			)
 
 			http.HandleFunc("/", cfg.HandleMyIP)


### PR DESCRIPTION
Adds support for a request header which provides the client ip address cleanly. This would come from an upstream load balancer or other service.