### PR TITLE
fix TrustedHeader Config handling

### DIFF
--- a/clientip/clientip.go
+++ b/clientip/clientip.go
@@ -14,13 +14,15 @@ type TrustedProxies struct {
 }
 
 // NewTrustedProxies parses a comma-separated list of CIDR blocks and returns a TrustedProxies struct.
-// Invalid CIDRs are skipped.
 func NewTrustedProxies(cidrList string) *TrustedProxies {
 	var nets []*net.IPNet
-	for _, cidr := range strings.Split(cidrList, ",") {
+	for cidr := range strings.SplitSeq(cidrList, ",") {
 		cidr = strings.TrimSpace(cidr)
 		if cidr == "" {
 			continue
+		}
+		if !strings.Contains(cidr, "/") {
+			cidr = cidr + "/32"
 		}
 		_, netw, err := net.ParseCIDR(cidr)
 		if err != nil {
@@ -43,6 +45,14 @@ func (tp *TrustedProxies) IsTrusted(ip string) bool {
 		}
 	}
 	return false
+}
+
+func (tp *TrustedProxies) String() string {
+	var proxies []string
+	for _, net := range tp.nets {
+		proxies = append(proxies, net.String())
+	}
+	return "[" + strings.Join(proxies, ", ") + "]"
 }
 
 // FlattenDelimitedInputs processes a slice of multiple delimited-value strings by splitting them on the delimiter,

--- a/handlers.go
+++ b/handlers.go
@@ -20,7 +20,7 @@ func (cfg *Config) HandleMyIP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ip := clientip.GetClientIP(r, cfg.trustXFF, cfg.trustedProxies, cfg.trustedHeader)
+	ip := clientip.GetClientIP(r, cfg.TrustXFF, cfg.TrustedProxies, cfg.TrustedHeader)
 
 	w.Header().Add(`Content-Type`, `application/json`)
 	_, err := fmt.Fprintf(w, "{\"ip\": \"%s\"}\n", ip)

--- a/main.go
+++ b/main.go
@@ -13,10 +13,10 @@ import (
 )
 
 type Config struct {
-	trustedProxies *clientip.TrustedProxies
-	trustedHeader  string
-	trustXFF       bool
-	listenAddr     string
+	TrustedProxies *clientip.TrustedProxies
+	TrustedHeader  string
+	TrustXFF       bool
+	ListenAddr     string
 }
 
 // command-line option init & defaults
@@ -99,9 +99,10 @@ func main() {
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			cfg := &Config{
-				trustedProxies: clientip.NewTrustedProxies(cmd.String("trustedproxies")),
-				trustXFF:       cmd.Bool("trustxff"),
-				listenAddr:     cmd.String("listenaddr"),
+				TrustedProxies: clientip.NewTrustedProxies(cmd.String("trustedproxies")),
+				TrustedHeader:  cmd.String("trustedheader"),
+				TrustXFF:       cmd.Bool("trustxff"),
+				ListenAddr:     cmd.String("listenaddr"),
 			}
 
 			logger.Info("starting up",
@@ -109,20 +110,14 @@ func main() {
 				"commit", commit,
 				"date", date,
 				"builder", builtBy,
-			)
-
-			logger.Info("configuration",
-				"listenaddr", cfg.listenAddr,
-				"trustxff", cfg.trustXFF,
-				"trustedproxies", cfg.trustedProxies,
-				"trustedheader", cfg.trustedHeader,
+				"config", cfg,
 			)
 
 			http.HandleFunc("/", cfg.HandleMyIP)
 
 			// Serve forever
 			logger.Info("listening for API connections")
-			if err := http.ListenAndServe(cfg.listenAddr, nil); err != nil {
+			if err := http.ListenAndServe(cfg.ListenAddr, nil); err != nil {
 				return err
 			}
 			return nil


### PR DESCRIPTION
* add missing TrustedHeader to Config at startup
* export Config members
* merge config logging into startup message
* allow ips without cidr mask
* improve logging of TrustedProxies